### PR TITLE
Hotfix/create user order and reset password

### DIFF
--- a/src/components/DataTables/UsersTable/index.js
+++ b/src/components/DataTables/UsersTable/index.js
@@ -1,15 +1,20 @@
 import React, {useEffect} from "react";
 import {useDispatch, useSelector} from "react-redux";
-import users from "../../../store/actions/users";
+import users, {resetPassword} from "../../../store/actions/users";
 import {getUsersSelector} from "../../../store/selectors/usersSelector";
 import DataTable from "../DataTable";
 import UserForm from "../../Forms/AdminForms/UserForm";
 import {Button} from "@mui/material";
-import {resetPassword} from "../../../store/actions/users";
 import store from "../../../store/store";
 
 function renderResetPasswordButton({value}) {
-    return <Button onClick={() => store.dispatch(resetPassword(value))}>Reset password</Button>;
+    const onClick = async () => {
+        const {error, payload} = await store.dispatch(resetPassword(value));
+        if (!error) {
+            console.log('Password reset');
+        }
+    }
+    return <Button onClick={onClick}>Reset password</Button>;
 }
 
 const columns = [

--- a/src/components/Dialogs/LogInAlertDialog/index.js
+++ b/src/components/Dialogs/LogInAlertDialog/index.js
@@ -10,7 +10,7 @@ const LogoutAlertDialog = () => {
             <Dialog open={true}>
                 <DialogTitle>Error!</DialogTitle>
                 <DialogContent>
-                    <Typography>You need to log in before placing new order on your account!</Typography>
+                    <Typography>You need to log in and prove your email before placing new order on your account!</Typography>
                 </DialogContent>
                 <DialogActions>
                     <Button onClick={() => {

--- a/src/components/Pages/MasterPages/MasterOrdersPage/index.js
+++ b/src/components/Pages/MasterPages/MasterOrdersPage/index.js
@@ -17,7 +17,7 @@ function renderStatus({id, value}) {
     const color = value ? 'green' : 'red';
     const text = value ? 'Completed' : 'Not completed';
 
-    return <Button onClick={()=> store.dispatch(orders.updateMasterOrderById({id, isCompleted: !value}))} sx={{color: color}}>{text}</Button>;
+    return <Button disabled={value} onClick={()=> store.dispatch(orders.updateMasterOrderById({id, isCompleted: !value}))} sx={{color: color}}>{text}</Button>;
 }
 
 const columns = [

--- a/src/store/actions/auth.js
+++ b/src/store/actions/auth.js
@@ -2,6 +2,7 @@ import {createAsyncThunk} from "@reduxjs/toolkit";
 import auth from "../constants/auth";
 import actionApi from "../middleware/createActionApi";
 import instance from "../middleware/instance";
+import baseHeaders from "../middleware/headers";
 
 export const signIn = createAsyncThunk(auth.SIGN_IN, actionApi.POST('/signin'));
 
@@ -14,9 +15,7 @@ export const verifyUserAccess = createAsyncThunk(auth.VERIFY_USER_ACCESS, action
 export const updateCredentials = createAsyncThunk(auth.UPDATE_CREDENTIALS, async (valuesToUpdate, thunkApi) => {
     try {
         const response = await instance.put('/update/credentials', valuesToUpdate,{
-            headers: {
-                'x-access-token': sessionStorage.getItem('TOKEN')
-            }
+            headers: {...baseHeaders}
         });
         return response.data || {};
     } catch (e) {
@@ -27,9 +26,7 @@ export const updateCredentials = createAsyncThunk(auth.UPDATE_CREDENTIALS, async
 export const verifyEmailState = createAsyncThunk(auth.VERIFY_EMAIL_STATE, async (url, thunkAPI) => {
     try {
         const response = await instance.get(url, {
-            headers: {
-                'x-access-token': sessionStorage.getItem('TOKEN')
-            }
+            headers: {...baseHeaders}
         });
         return response.data || {};
     } catch (e) {

--- a/src/store/actions/auth.js
+++ b/src/store/actions/auth.js
@@ -2,7 +2,6 @@ import {createAsyncThunk} from "@reduxjs/toolkit";
 import auth from "../constants/auth";
 import actionApi from "../middleware/createActionApi";
 import instance from "../middleware/instance";
-import baseHeaders from "../middleware/headers";
 
 export const signIn = createAsyncThunk(auth.SIGN_IN, actionApi.POST('/signin'));
 
@@ -14,7 +13,11 @@ export const verifyUserAccess = createAsyncThunk(auth.VERIFY_USER_ACCESS, action
 
 export const updateCredentials = createAsyncThunk(auth.UPDATE_CREDENTIALS, async (valuesToUpdate, thunkApi) => {
     try {
-        const response = await instance.get(url, {...baseHeaders});
+        const response = await instance.put('/update/credentials', valuesToUpdate,{
+            headers: {
+                'x-access-token': sessionStorage.getItem('TOKEN')
+            }
+        });
         return response.data || {};
     } catch (e) {
         return thunkApi.rejectWithValue(e.response.data);

--- a/src/store/actions/users.js
+++ b/src/store/actions/users.js
@@ -1,6 +1,5 @@
 import {createAsyncThunk} from "@reduxjs/toolkit";
 import users from "../constants/users";
-import auth from "../constants/auth";
 import instance from "../middleware/instance";
 import actionApi from "../middleware/createActionApi";
 
@@ -16,7 +15,7 @@ const getUserById = createAsyncThunk(users.GET_USER_BY_ID, actionApi.GET_BY_ID('
 
 export const resetPassword = createAsyncThunk(users.RESET_PASSWORD, async (id, thunkAPI) => {
     try {
-        const response = await instance.put('/reset/password/'+ id, {
+        const response = await instance.put('/reset/password/' + id, {}, {
             headers: {
                 'x-access-token': sessionStorage.getItem('TOKEN')
             }

--- a/src/store/actions/users.js
+++ b/src/store/actions/users.js
@@ -2,6 +2,7 @@ import {createAsyncThunk} from "@reduxjs/toolkit";
 import users from "../constants/users";
 import instance from "../middleware/instance";
 import actionApi from "../middleware/createActionApi";
+import baseHeaders from "../middleware/headers";
 
 const addUser = createAsyncThunk(users.ADD_USER, actionApi.POST('/users'));
 
@@ -16,9 +17,7 @@ const getUserById = createAsyncThunk(users.GET_USER_BY_ID, actionApi.GET_BY_ID('
 export const resetPassword = createAsyncThunk(users.RESET_PASSWORD, async (id, thunkAPI) => {
     try {
         const response = await instance.put('/reset/password/' + id, {}, {
-            headers: {
-                'x-access-token': sessionStorage.getItem('TOKEN')
-            }
+            headers: {...baseHeaders}
         });
         return response.data;
     } catch (e) {

--- a/src/store/actions/users.js
+++ b/src/store/actions/users.js
@@ -16,7 +16,7 @@ const getUserById = createAsyncThunk(users.GET_USER_BY_ID, actionApi.GET_BY_ID('
 
 export const resetPassword = createAsyncThunk(users.RESET_PASSWORD, async (id, thunkAPI) => {
     try {
-        const response = await instance.put('/reset/password/' + id, {}, {
+        const response = await instance.put(`/reset/password/${id}`, {}, {
             headers: {...baseHeaders}
         });
         return response.data;

--- a/src/store/middleware/createActionApi.js
+++ b/src/store/middleware/createActionApi.js
@@ -14,7 +14,7 @@ export default {
     },
     GET_BY_ID: (path) => async (id, thunkAPI) => {
         try {
-            const response = await instance.get(path + '/' + id, {
+            const response = await instance.get(`${path}/${id}`, {
                 headers: {...baseHeaders}
             });
             return response.data || {};
@@ -34,7 +34,7 @@ export default {
     },
     PUT: (path) => async ({id, ...updateValues}, thunkAPI) => {
         try {
-            const response = await instance.put(path + '/' + id, updateValues, {
+            const response = await instance.put(`${path}/${id}`, updateValues, {
                 headers: {...baseHeaders}
             });
             return response.data;
@@ -44,7 +44,7 @@ export default {
     },
     DELETE: (path) => async (id, thunkAPI) => {
         try {
-            const response = await instance.delete(path + '/' + id, {
+            const response = await instance.delete(`${path}/${id}`, {
                 headers: {...baseHeaders}
             });
             return response.data;

--- a/src/store/middleware/createActionApi.js
+++ b/src/store/middleware/createActionApi.js
@@ -16,7 +16,11 @@ export default {
     },
     GET_BY_ID: (path) => async (id, thunkAPI) => {
         try {
-            const response = await instance.get(path + '/' + id, {...baseHeaders});
+            const response = await instance.get(path + '/' + id, {
+                headers: {
+                    'x-access-token': sessionStorage.getItem('TOKEN')
+                }
+            });
             return response.data || {};
         } catch (e) {
             return thunkAPI.rejectWithValue(e.response.data)
@@ -24,7 +28,9 @@ export default {
     },
     POST: (path) => async (newInstance, thunkAPI) => {
         try {
-            const response = await instance.post(path, newInstance, {...baseHeaders});
+            const response = await instance.post(path, newInstance, {headers: {
+                    'x-access-token': sessionStorage.getItem('TOKEN')
+                }});
             return response.data;
         } catch (e) {
             return thunkAPI.rejectWithValue(e.response.data)
@@ -32,8 +38,9 @@ export default {
     },
     PUT: (path) => async ({id, ...updateValues}, thunkAPI) => {
         try {
-            console.log(updateValues)
-            const response = await instance.put(path + '/' + id, updateValues, {...baseHeaders});
+            const response = await instance.put(path + '/' + id, updateValues, {headers: {
+                    'x-access-token': sessionStorage.getItem('TOKEN')
+                }});
             return response.data;
         } catch (e) {
             return thunkAPI.rejectWithValue(e.response.data)
@@ -41,7 +48,9 @@ export default {
     },
     DELETE: (path) => async (id, thunkAPI) => {
         try {
-            const response = await instance.delete(path + '/' + id, {...baseHeaders});
+            const response = await instance.delete(path + '/' + id, {headers: {
+                    'x-access-token': sessionStorage.getItem('TOKEN')
+                }});
             return response.data;
         } catch (e) {
             return thunkAPI.rejectWithValue(e.response.data)

--- a/src/store/middleware/createActionApi.js
+++ b/src/store/middleware/createActionApi.js
@@ -5,9 +5,7 @@ export default {
     GET: (path) => async (_, thunkAPI) => {
         try {
             const response = await instance.get(path, {
-                headers: {
-                    'x-access-token': sessionStorage.getItem('TOKEN')
-                }
+                headers: {...baseHeaders}
             });
             return response.data || {};
         } catch (e) {
@@ -17,9 +15,7 @@ export default {
     GET_BY_ID: (path) => async (id, thunkAPI) => {
         try {
             const response = await instance.get(path + '/' + id, {
-                headers: {
-                    'x-access-token': sessionStorage.getItem('TOKEN')
-                }
+                headers: {...baseHeaders}
             });
             return response.data || {};
         } catch (e) {
@@ -28,9 +24,9 @@ export default {
     },
     POST: (path) => async (newInstance, thunkAPI) => {
         try {
-            const response = await instance.post(path, newInstance, {headers: {
-                    'x-access-token': sessionStorage.getItem('TOKEN')
-                }});
+            const response = await instance.post(path, newInstance, {
+                headers: {...baseHeaders}
+            });
             return response.data;
         } catch (e) {
             return thunkAPI.rejectWithValue(e.response.data)
@@ -38,9 +34,9 @@ export default {
     },
     PUT: (path) => async ({id, ...updateValues}, thunkAPI) => {
         try {
-            const response = await instance.put(path + '/' + id, updateValues, {headers: {
-                    'x-access-token': sessionStorage.getItem('TOKEN')
-                }});
+            const response = await instance.put(path + '/' + id, updateValues, {
+                headers: {...baseHeaders}
+            });
             return response.data;
         } catch (e) {
             return thunkAPI.rejectWithValue(e.response.data)
@@ -48,9 +44,9 @@ export default {
     },
     DELETE: (path) => async (id, thunkAPI) => {
         try {
-            const response = await instance.delete(path + '/' + id, {headers: {
-                    'x-access-token': sessionStorage.getItem('TOKEN')
-                }});
+            const response = await instance.delete(path + '/' + id, {
+                headers: {...baseHeaders}
+            });
             return response.data;
         } catch (e) {
             return thunkAPI.rejectWithValue(e.response.data)

--- a/src/store/middleware/headers.js
+++ b/src/store/middleware/headers.js
@@ -1,7 +1,5 @@
 const baseHeaders = {
-    headers: {
-        'x-access-token': sessionStorage.getItem('TOKEN')
-    }
+    'x-access-token': sessionStorage.getItem('TOKEN')
 };
 
 export default baseHeaders;

--- a/src/store/reducers/authReducer.js
+++ b/src/store/reducers/authReducer.js
@@ -63,7 +63,7 @@ const {reducer} = createSlice({
                 state.auth.currentUser.emailChecked = true;
             })
             .addCase(updateCredentials.fulfilled, (state, action) => {
-                //credentials updated
+                state.auth.currentUser = action.payload;
             })
             .addDefaultCase((state, action) => {
                 return state;


### PR DESCRIPTION
- Deleted usage of baseHeaders as they dont work properly.
- Fixed reset password request; after updating credentials update also currentUser in store; show admin that password is reset
- Change text of LogoutAlertDialog to that user know that one also need to prove email
- Disable button that changes status of order when order is completed